### PR TITLE
Allow passphraser to be calleded from anywhere

### DIFF
--- a/passphraser.csproj
+++ b/passphraser.csproj
@@ -10,6 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <None Include="wordlist/wordlist.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request improves how the application handles the wordlist file path.
Making sure the wordlist is part of the build output and relative to the executable.

- Added a `--wordlist` command-line option to specify the wordlist file path,
defaulting to the `wordlist/wordlist.txt` in the output directory.
- Configured the project to copy `wordlist/wordlist.txt` to the output directory on build,
ensuring the default wordlist is always available.